### PR TITLE
chore: add MATCH_STATES

### DIFF
--- a/src/models/matchModel.js
+++ b/src/models/matchModel.js
@@ -1,11 +1,18 @@
 const { v4: uuidv4 } = require('uuid');
 
+const MATCH_STATES = {
+  WAITING: 'waiting',
+  IN_PROGRESS: 'in_progress',
+  FINISHED: 'finished',
+  CANCELLED: 'cancelled',
+};
+
 class Match {
   constructor({ name }) {
     this.id = uuidv4();
     this.name = name;
     this.players = []; // máximo de 4 jogadores
-    this.state = 'waiting'; // waiting | in_progress | finished
+    this.state = MATCH_STATES.WAITING;
     this.startDate = null;
     this.scores = {}; // { playerId: score }
   }


### PR DESCRIPTION
- **Evita erro de digitação:** Usar constantes reduz o risco de escrever 'in_progres' sem perceber.
- **Facilita validação:** Você pode validar se state é um dos valores de MATCH_STATES de forma clara.
- **Facilita alterações futuras:** Se quiser renomear in_progress para ongoing, por exemplo, basta mudar num único lugar.
- **Mais legível e profissional:** Deixa o código mais robusto e expressivo — especialmente útil em equipes. 